### PR TITLE
Improve Shodan UI sizing and add menu for geo-info

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -62,7 +62,6 @@ pub enum ActiveBlock {
     SearchResult,
     Home,
     Input,
-    Shodan,
     ShodanMenu,
     ShodanUnloaded,
     ShodanServices,

--- a/src/app.rs
+++ b/src/app.rs
@@ -1,6 +1,6 @@
 use super::config::Config;
 use super::user_config::UserConfig;
-use crate::clients::shodan::{ServiceData, ShodanSearchIp};
+use crate::clients::shodan::{Location, ServiceData, ShodanSearchIp};
 use crate::clients::virustotal::{AnalysisStats, Attributes, Data, IpAddress, Votes};
 use crate::network::IoEvent;
 use std::collections::HashMap;
@@ -15,14 +15,15 @@ const DEFAULT_ROUTE: Route = Route {
 
 #[derive(Clone, PartialEq, Debug)]
 pub enum RouteId {
-    Error,
     Home,
     Search,
     SearchResult,
     Shodan,
-    Unloaded,
+    ShodanGeoLookup,
     VirustotalDetection,
     VirustotalDetails,
+    Unloaded,
+    Error,
 }
 
 pub const VIRUSTOTAL_MENU: [&str; 2] = ["Detection", "Details"];
@@ -35,8 +36,11 @@ pub struct Virustotal {
     pub ip_whois_items: IpAddress,
 }
 
+pub const SHODAN_MENU: [&str; 2] = ["General", "Geo-Lookup"];
+
 pub struct Shodan {
     pub service_index: usize,
+    pub menu_index: usize,
     pub search_ip_items: ShodanSearchIp,
 }
 
@@ -59,6 +63,7 @@ pub enum ActiveBlock {
     Home,
     Input,
     Shodan,
+    ShodanMenu,
     ShodanUnloaded,
     ShodanServices,
     VirustotalMenu,
@@ -76,10 +81,6 @@ pub struct App {
     pub is_loading: bool,
     pub is_input_error: bool,
     pub api_error: String,
-    pub help_menu_page: u32,
-    pub help_menu_offset: u32,
-    pub help_docs_size: u32,
-    pub help_menu_max_lines: u32,
     pub size: Rect,
     // Inputs:
     // input is the string for input;
@@ -131,6 +132,7 @@ impl Default for App {
             },
             shodan: Shodan {
                 service_index: 0,
+                menu_index: 0,
                 search_ip_items: ShodanSearchIp {
                     ip_str: Some(String::new()),
                     org: String::new(),
@@ -144,6 +146,15 @@ impl Default for App {
                         product: Some(String::new()),
                         transport: Some(String::new()),
                         port: 0,
+                        location: Some(Location {
+                            area_code: Some(0),
+                            city: Some(String::new()),
+                            country_code: Some(String::new()),
+                            country_name: Some(String::new()),
+                            latitude: Some(0.0),
+                            longitude: Some(0.0),
+                            region_code: Some(String::new()),
+                        }),
                     }]),
                     ports: Some(vec![0]),
                     latitude: 0.00,
@@ -163,10 +174,6 @@ impl Default for App {
             input_cursor_position: 0,
             user_config: UserConfig::new(),
             client_config: Config::new(),
-            help_menu_offset: 0,
-            help_menu_page: 0,
-            help_docs_size: 0,
-            help_menu_max_lines: 0,
             size: Rect::default(),
         }
     }

--- a/src/clients/shodan/models.rs
+++ b/src/clients/shodan/models.rs
@@ -1,7 +1,6 @@
 use serde::{Deserialize, Serialize};
 
 #[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
 pub struct ShodanSearchIp {
     #[serde(rename = "ip_str")]
     pub ip_str: Option<String>,
@@ -21,13 +20,24 @@ pub struct ShodanSearchIp {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
 pub struct ServiceData {
     #[serde(rename = "data")]
     pub service: Option<String>,
     pub product: Option<String>,
     pub port: i32,
     pub transport: Option<String>,
+    pub location: Option<Location>,
+}
+
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct Location {
+    pub area_code: Option<usize>,
+    pub city: Option<String>,
+    pub country_code: Option<String>,
+    pub country_name: Option<String>,
+    pub latitude: Option<f64>,
+    pub longitude: Option<f64>,
+    pub region_code: Option<String>,
 }
 
 impl ShodanSearchIp {

--- a/src/handlers/common_key_events.rs
+++ b/src/handlers/common_key_events.rs
@@ -51,7 +51,6 @@ pub fn on_up_press_handler<T>(selection_data: &[T], selection_index: Option<usiz
 }
 
 pub fn handle_right_event(app: &mut App) {
-    // TODO:
     match app.get_current_route().hovered_block {
         ActiveBlock::Home | ActiveBlock::Empty => match app.get_current_route().id {
             RouteId::Home => {
@@ -64,6 +63,7 @@ pub fn handle_right_event(app: &mut App) {
             RouteId::VirustotalDetails => {}
             RouteId::Unloaded => {}
             RouteId::Shodan => {}
+            RouteId::ShodanGeoLookup => {}
             RouteId::Error => {}
             RouteId::SearchResult => {}
         },

--- a/src/handlers/home.rs
+++ b/src/handlers/home.rs
@@ -1,4 +1,4 @@
-use super::{super::app::App};
+use super::super::app::App;
 use crate::event::Key;
 
 pub fn handler(_key: Key, _app: &mut App) {}

--- a/src/handlers/mod.rs
+++ b/src/handlers/mod.rs
@@ -86,6 +86,9 @@ fn handle_block_events(key: Key, app: &mut App) {
         ActiveBlock::Shodan => {
             shodan::handler(key, app);
         }
+        ActiveBlock::ShodanMenu => {
+            shodan::handler(key, app);
+        }
         ActiveBlock::ShodanServices => {
             shodan::handler(key, app);
         }

--- a/src/handlers/mod.rs
+++ b/src/handlers/mod.rs
@@ -42,7 +42,7 @@ pub fn handle_app(key: Key, app: &mut App) {
             if app.client_config.keys.shodan.is_empty() {
                 app.push_navigation_stack(RouteId::Unloaded, ActiveBlock::ShodanUnloaded);
             } else {
-                app.push_navigation_stack(RouteId::Shodan, ActiveBlock::Shodan);
+                app.push_navigation_stack(RouteId::Shodan, ActiveBlock::ShodanMenu);
             }
         }
         _ => handle_block_events(key, app),
@@ -82,9 +82,6 @@ fn handle_block_events(key: Key, app: &mut App) {
         }
         ActiveBlock::VirustotalUnloaded => {
             unloaded::handler(key, app);
-        }
-        ActiveBlock::Shodan => {
-            shodan::handler(key, app);
         }
         ActiveBlock::ShodanMenu => {
             shodan::handler(key, app);

--- a/src/handlers/search_result.rs
+++ b/src/handlers/search_result.rs
@@ -1,4 +1,4 @@
-use super::{super::app::App};
+use super::super::app::App;
 use crate::event::Key;
 
 pub fn handler(_key: Key, _app: &mut App) {}

--- a/src/handlers/shodan.rs
+++ b/src/handlers/shodan.rs
@@ -1,4 +1,28 @@
-use super::{super::app::App};
-use crate::event::Key;
+use super::{super::app::App, common_key_events, ActiveBlock, RouteId};
+use crate::{app::SHODAN_MENU, event::Key};
 
-pub fn handler(_key: Key, _app: &mut App) {}
+pub fn handler(key: Key, app: &mut App) {
+    match key {
+        k if common_key_events::down_event(k) => {
+            let next_index =
+                common_key_events::on_down_press_handler(&SHODAN_MENU, Some(app.shodan.menu_index));
+            app.shodan.menu_index = next_index;
+            switch_view(app);
+        }
+        k if common_key_events::up_event(k) => {
+            let next_index =
+                common_key_events::on_up_press_handler(&SHODAN_MENU, Some(app.shodan.menu_index));
+            app.shodan.menu_index = next_index;
+            switch_view(app);
+        }
+        _ => (),
+    };
+}
+
+fn switch_view(app: &mut App) {
+    match app.shodan.menu_index {
+        0 => app.push_navigation_stack(RouteId::Shodan, ActiveBlock::ShodanMenu),
+        1 => app.push_navigation_stack(RouteId::ShodanGeoLookup, ActiveBlock::ShodanMenu),
+        _ => {}
+    }
+}

--- a/src/handlers/virustotal.rs
+++ b/src/handlers/virustotal.rs
@@ -13,8 +13,8 @@ pub fn handler(key: Key, app: &mut App) {
                     match app.get_current_route().id {
                         RouteId::VirustotalDetection => {
                             app.set_current_route_state(
-                                Some(ActiveBlock::VirustotalSummary),
-                                Some(ActiveBlock::VirustotalSummary),
+                                Some(ActiveBlock::VirustotalResults),
+                                Some(ActiveBlock::VirustotalResults),
                             );
                         }
                         RouteId::VirustotalDetails => {
@@ -26,37 +26,18 @@ pub fn handler(key: Key, app: &mut App) {
                         _ => {}
                     }
                 }
-                // If the user is currently on the `Summary` block, take them to `Results`
-                ActiveBlock::VirustotalSummary => match app.get_current_route().id {
-                    RouteId::VirustotalDetection => {
-                        app.set_current_route_state(
-                            Some(ActiveBlock::VirustotalResults),
-                            Some(ActiveBlock::VirustotalResults),
-                        );
-                    }
-                    _ => {}
-                },
                 _ => {}
             };
         }
         k if common_key_events::left_event(k) => {
             match app.get_current_route().hovered_block {
                 ActiveBlock::VirustotalMenu | ActiveBlock::Empty => {}
-                // If the user is currently on the `Summary` block, take them to `Menu`
-                ActiveBlock::VirustotalSummary => match app.get_current_route().id {
-                    RouteId::VirustotalDetection => {
-                        app.set_current_route_state(
-                            Some(ActiveBlock::VirustotalMenu),
-                            Some(ActiveBlock::VirustotalMenu),
-                        );
-                    }
-                    _ => {}
-                },
+                // If the user is currently on the `Results` block, take them to `Menu`
                 ActiveBlock::VirustotalResults => match app.get_current_route().id {
                     RouteId::VirustotalDetection => {
                         app.set_current_route_state(
-                            Some(ActiveBlock::VirustotalSummary),
-                            Some(ActiveBlock::VirustotalSummary),
+                            Some(ActiveBlock::VirustotalMenu),
+                            Some(ActiveBlock::VirustotalMenu),
                         );
                     }
                     _ => {}
@@ -84,7 +65,7 @@ pub fn handler(key: Key, app: &mut App) {
     };
 }
 
-pub fn switch_view(app: &mut App) {
+fn switch_view(app: &mut App) {
     match app.virustotal.selected_index {
         0 => app.push_navigation_stack(RouteId::VirustotalDetection, ActiveBlock::VirustotalMenu),
         1 => app.push_navigation_stack(RouteId::VirustotalDetails, ActiveBlock::VirustotalMenu),

--- a/src/handlers/virustotal_results.rs
+++ b/src/handlers/virustotal_results.rs
@@ -5,7 +5,6 @@ use super::{
 use crate::event::Key;
 
 pub fn handler(key: Key, app: &mut App) {
-    // TODO: Add helper function to app
     let results: Vec<String> = app
         .virustotal
         .ip_whois_items

--- a/src/handlers/virustotal_summary.rs
+++ b/src/handlers/virustotal_summary.rs
@@ -7,33 +7,23 @@ use crate::event::Key;
 pub fn handler(key: Key, app: &mut App) {
     match key {
         k if common_key_events::right_event(k) => {
-            match app.get_current_route().hovered_block {
-                // If the user is currently on the `Summary` block, take them to `Results`
-                ActiveBlock::VirustotalSummary => match app.get_current_route().id {
-                    RouteId::VirustotalDetection => {
-                        app.set_current_route_state(
-                            Some(ActiveBlock::VirustotalResults),
-                            Some(ActiveBlock::VirustotalResults),
-                        );
-                    }
-                    _ => {}
-                },
-                _ => {}
+            if app.get_current_route().hovered_block == ActiveBlock::VirustotalSummary {
+                if app.get_current_route().id == RouteId::VirustotalDetection {
+                    app.set_current_route_state(
+                        Some(ActiveBlock::VirustotalResults),
+                        Some(ActiveBlock::VirustotalResults),
+                    );
+                };
             };
         }
         k if common_key_events::left_event(k) => {
-            match app.get_current_route().hovered_block {
-                // If the user is currently on the `Summary` block, take them to `Menu`
-                ActiveBlock::VirustotalSummary => match app.get_current_route().id {
-                    RouteId::VirustotalDetection => {
-                        app.set_current_route_state(
-                            Some(ActiveBlock::VirustotalMenu),
-                            Some(ActiveBlock::VirustotalMenu),
-                        );
-                    }
-                    _ => {}
-                },
-                _ => {}
+            if app.get_current_route().hovered_block == ActiveBlock::VirustotalSummary {
+                if app.get_current_route().id == RouteId::VirustotalDetection {
+                    app.set_current_route_state(
+                        Some(ActiveBlock::VirustotalMenu),
+                        Some(ActiveBlock::VirustotalMenu),
+                    );
+                };
             };
         }
         _ => (),

--- a/src/handlers/virustotal_whois.rs
+++ b/src/handlers/virustotal_whois.rs
@@ -5,7 +5,6 @@ use super::{
 use crate::event::Key;
 
 pub fn handler(key: Key, app: &mut App) {
-    // TODO: Add helper function to app
     let results: Vec<&str> = app
         .virustotal
         .ip_whois_items

--- a/src/main.rs
+++ b/src/main.rs
@@ -99,11 +99,7 @@ async fn start_ui(app: &Arc<Mutex<App>>) -> Result<(), Box<dyn std::error::Error
             terminal.hide_cursor()?;
         }
 
-        let cursor_offset = if app.size.height > ui::util::SMALL_TERMINAL_HEIGHT {
-            3
-        } else {
-            3
-        };
+        let cursor_offset = 3;
 
         // Put the cursor back inside the input box
         terminal.backend_mut().execute(MoveTo(

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -7,7 +7,7 @@ use super::{
     banner::BANNER,
 };
 use crate::ui::{
-    shodan::draw_shodan,
+    shodan::{draw_shodan, draw_shodan_geo_lookup},
     util::get_color,
     virustotal::{draw_virustotal_details, draw_virustotal_detection},
 };
@@ -105,6 +105,9 @@ where
         RouteId::Shodan => {
             draw_shodan(f, app, chunks[0]);
         }
+        RouteId::ShodanGeoLookup => {
+            draw_shodan_geo_lookup(f, app, chunks[0]);
+        }
         RouteId::Error => {} // This is handled as a "full screen" route in main.rs
     };
 }
@@ -178,7 +181,10 @@ where
     };
 
     let block = Block::default()
-        .title(Span::styled("Status", Style::default().fg(help_block_text.0)))
+        .title(Span::styled(
+            "Status",
+            Style::default().fg(help_block_text.0),
+        ))
         .borders(Borders::ALL)
         .border_style(Style::default().fg(help_block_text.0));
 

--- a/src/ui/shodan.rs
+++ b/src/ui/shodan.rs
@@ -83,7 +83,7 @@ where
                 .title("🌐 General Information")
                 .border_type(BorderType::Plain),
         )
-        .widths(&[Constraint::Length(20), Constraint::Length(20)]);
+        .widths(&[Constraint::Length(20), Constraint::Percentage(100)]);
 
     f.render_widget(summary, layout_chunk);
 }

--- a/src/ui/shodan.rs
+++ b/src/ui/shodan.rs
@@ -1,12 +1,16 @@
-use super::super::app::{ActiveBlock, App};
-use crate::ui::{draw_table, util::get_percentage_width, TableHeader, TableHeaderItem, TableItem};
+use super::super::app::{ActiveBlock, App, SHODAN_MENU};
+use crate::ui::{
+    draw_selectable_list, draw_table, util::get_percentage_width, TableHeader, TableHeaderItem,
+    TableItem,
+};
 use tui::{
     backend::Backend,
     layout::{Constraint, Direction, Layout, Rect},
     style::{Color, Modifier, Style},
     symbols,
+    text::{Span, Spans},
     widgets::canvas::{Canvas, Map, MapResolution},
-    widgets::{Block, BorderType, Borders, Cell, Row, Table},
+    widgets::{Block, BorderType, Borders, Cell, Paragraph, Row, Table, Wrap},
     Frame,
 };
 
@@ -19,17 +23,38 @@ where
         .direction(Direction::Horizontal)
         .constraints(
             [
-                Constraint::Percentage(20),
-                Constraint::Percentage(20),
+                Constraint::Percentage(10),
+                Constraint::Percentage(30),
                 Constraint::Percentage(60),
             ]
             .as_ref(),
         )
         .split(layout_chunk);
 
-    draw_summary(f, app, chunks[0]);
-    draw_services(f, app, chunks[1]);
-    draw_map(f, app, chunks[2]);
+    draw_shodan_menu(f, app, chunks[0]);
+    draw_summary(f, app, chunks[1]);
+    draw_services(f, app, chunks[2]);
+}
+
+pub fn draw_shodan_menu<B>(f: &mut Frame<B>, app: &App, layout_chunk: Rect)
+where
+    B: Backend,
+{
+    let current_route = app.get_current_route();
+    let highlight_state = (
+        current_route.active_block == ActiveBlock::ShodanMenu,
+        current_route.hovered_block == ActiveBlock::ShodanMenu,
+    );
+
+    draw_selectable_list(
+        f,
+        app,
+        layout_chunk,
+        "Menu",
+        &SHODAN_MENU,
+        highlight_state,
+        Some(app.shodan.menu_index),
+    );
 }
 
 pub fn draw_summary<B>(f: &mut Frame<B>, app: &App, layout_chunk: Rect)
@@ -72,17 +97,14 @@ where
             TableHeaderItem {
                 text: "Port",
                 width: get_percentage_width(layout_chunk.width, 0.3),
-                ..Default::default()
             },
             TableHeaderItem {
                 text: "Transport",
                 width: get_percentage_width(layout_chunk.width, 0.3),
-                ..Default::default()
             },
             TableHeaderItem {
                 text: "Service",
                 width: get_percentage_width(layout_chunk.width, 0.3),
-                ..Default::default()
             },
         ],
     };
@@ -93,7 +115,7 @@ where
         current_route.hovered_block == ActiveBlock::ShodanServices,
     );
 
-    let items = app
+    let items = &app
         .shodan
         .search_ip_items
         .data
@@ -103,13 +125,13 @@ where
         .map(|services| TableItem {
             format: vec![
                 services.port.to_string(),
-                match services.transport.to_owned() {
-                    Some(transport) => transport,
-                    None => "N/A".to_string()
+                match &services.transport {
+                    Some(transport) => transport.to_string(),
+                    None => "N/A".to_string(),
                 },
-                match services.product.to_owned() {
-                    Some(product) => product,
-                    None => "N/A".to_string()
+                match &services.product {
+                    Some(product) => product.to_string(),
+                    None => "N/A".to_string(),
                 },
             ],
         })
@@ -120,10 +142,71 @@ where
         app,
         layout_chunk,
         ("Services", &header),
-        &items,
+        items,
         app.shodan.service_index,
         highlight_state,
     );
+}
+
+pub fn draw_geo_info<B>(f: &mut Frame<B>, app: &App, layout_chunk: Rect)
+where
+    B: Backend,
+{
+    let items = &app.shodan.search_ip_items;
+
+    let text = vec![
+        Spans::from(Span::styled(
+            format!("Lat: {}", &items.latitude),
+            Style::default().fg(app.user_config.theme.inactive),
+        )),
+        Spans::from(Span::styled(
+            format!("Lon: {}", &items.longitude),
+            Style::default().fg(app.user_config.theme.inactive),
+        )),
+        Spans::from(Span::styled(
+            format!(
+                "City: {}",
+                match &items.city {
+                    Some(city) => city.to_string(),
+                    None => "N/A".to_string(),
+                }
+            ),
+            Style::default().fg(app.user_config.theme.inactive),
+        )),
+        Spans::from(Span::styled(
+            format!(
+                "County: {}",
+                match &items.country_name {
+                    Some(country) => country.to_string(),
+                    None => "N/A".to_string(),
+                }
+            ),
+            Style::default().fg(app.user_config.theme.inactive),
+        )),
+        Spans::from(Span::styled(
+            format!(
+                "Code: {}",
+                match &items.country_code {
+                    Some(code) => code.to_string(),
+                    None => "N/A".to_string(),
+                }
+            ),
+            Style::default().fg(app.user_config.theme.inactive),
+        )),
+    ];
+
+    let paragraph = Paragraph::new(text)
+        .wrap(Wrap { trim: true })
+        .style(Style::default().fg(app.user_config.theme.text))
+        .block(
+            Block::default()
+                .borders(Borders::ALL)
+                .style(Style::default().fg(Color::White))
+                .title("Geo Info")
+                .border_type(BorderType::Plain),
+        );
+
+    f.render_widget(paragraph, layout_chunk);
 }
 
 pub fn draw_map<B>(f: &mut Frame<B>, app: &App, layout_chunk: Rect)
@@ -131,7 +214,7 @@ where
     B: Backend,
 {
     let map = Canvas::default()
-        .block(Block::default().title("World").borders(Borders::ALL))
+        .block(Block::default().title("Geo Lookup").borders(Borders::ALL))
         .paint(|ctx| {
             ctx.draw(&Map {
                 color: Color::White,
@@ -150,4 +233,25 @@ where
         .y_bounds([-90.0, 90.0]);
 
     f.render_widget(map, layout_chunk);
+}
+
+pub fn draw_shodan_geo_lookup<B>(f: &mut Frame<B>, app: &App, layout_chunk: Rect)
+where
+    B: Backend,
+{
+    let chunks = Layout::default()
+        .direction(Direction::Horizontal)
+        .constraints(
+            [
+                Constraint::Percentage(10),
+                Constraint::Percentage(20),
+                Constraint::Percentage(70),
+            ]
+            .as_ref(),
+        )
+        .split(layout_chunk);
+
+    draw_shodan_menu(f, app, chunks[0]);
+    draw_geo_info(f, app, chunks[1]);
+    draw_map(f, app, chunks[2]);
 }

--- a/src/ui/util.rs
+++ b/src/ui/util.rs
@@ -1,7 +1,5 @@
 use tui::style::{Color, Style};
 
-pub const SMALL_TERMINAL_HEIGHT: u16 = 45;
-
 pub fn get_color((is_active, is_hovered): (bool, bool)) -> Style {
     match (is_active, is_hovered) {
         (true, _) => Style::default().fg(Color::LightYellow),

--- a/src/ui/virustotal.rs
+++ b/src/ui/virustotal.rs
@@ -1,4 +1,4 @@
-use super::super::app::{ActiveBlock, App};
+use super::super::app::{ActiveBlock, App, VIRUSTOTAL_MENU};
 use crate::clients::virustotal::AnalysisResult;
 use crate::ui::util::{get_color, get_percentage_width};
 use crate::ui::{draw_selectable_list, draw_table, TableHeader, TableHeaderItem, TableItem};
@@ -21,14 +21,12 @@ where
         current_route.hovered_block == ActiveBlock::VirustotalMenu,
     );
 
-    let menu_list = ["Detection", "Details", "Relations", "Community"];
-
     draw_selectable_list(
         f,
         app,
         layout_chunk,
         "Menu",
-        &menu_list,
+        &VIRUSTOTAL_MENU,
         highlight_state,
         Some(app.virustotal.selected_index),
     );
@@ -127,12 +125,10 @@ where
             TableHeaderItem {
                 text: "Engine",
                 width: get_percentage_width(layout_chunk.width, 0.3),
-                ..Default::default()
             },
             TableHeaderItem {
                 text: "Result",
                 width: get_percentage_width(layout_chunk.width, 0.3),
-                ..Default::default()
             },
         ],
     };
@@ -214,7 +210,6 @@ where
         items: vec![TableHeaderItem {
             text: "",
             width: 100,
-            ..Default::default()
         }],
     };
 

--- a/src/user_config.rs
+++ b/src/user_config.rs
@@ -71,3 +71,9 @@ impl UserConfig {
         }
     }
 }
+
+impl Default for UserConfig {
+    fn default() -> Self {
+        Self::new()
+    }
+}


### PR DESCRIPTION
The Shodan view was crowded and had a hard time display longer text elements without getting chopped off. This moves the map block into a different view and uses the same menu strategy as `Virustotal`. 

We also add a Geo-Info summary block to provide more context around the map.

There's also some minor cleanup based on recommendations from `clippy` and redundant code.