### PR TITLE
resolves reqwest::Error missing field whois, issue 8

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "osintui"
-version = "0.1.0"
+version = "0.1.1"
 license = "MIT"
 description = "Open Source Intelligence Terminal User Interface"
 edition = "2021"

--- a/src/app.rs
+++ b/src/app.rs
@@ -120,7 +120,7 @@ impl Default for App {
                             asn: 0,
                             continent: String::new(),
                             network: String::new(),
-                            whois: String::new(),
+                            whois: Some(String::new()),
                             total_votes: Votes {
                                 harmless: 0,
                                 malicious: 0,

--- a/src/clients/virustotal/model.rs
+++ b/src/clients/virustotal/model.rs
@@ -15,7 +15,7 @@ pub struct IpData {
 #[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct IpAttributes {
     pub as_owner: String,
-    pub whois: String,
+    pub whois: Option<String>,
     pub asn: i32,
     pub continent: String,
     pub network: String,

--- a/src/handlers/virustotal_whois.rs
+++ b/src/handlers/virustotal_whois.rs
@@ -5,14 +5,13 @@ use super::{
 use crate::event::Key;
 
 pub fn handler(key: Key, app: &mut App) {
-    let results: Vec<&str> = app
-        .virustotal
-        .ip_whois_items
-        .data
-        .attributes
-        .whois
-        .split('\n')
-        .collect::<Vec<&str>>();
+    let whois = app.virustotal.ip_whois_items.data.attributes.whois.clone();
+    let results: String = match whois {
+            Some(items) => items.to_string(),
+            None => "No Whois data found.".to_string(),
+        };
+
+    let results = results.split('\n').collect::<Vec<&str>>();
 
     match key {
         k if common_key_events::right_event(k) => {

--- a/src/handlers/virustotal_whois.rs
+++ b/src/handlers/virustotal_whois.rs
@@ -7,9 +7,9 @@ use crate::event::Key;
 pub fn handler(key: Key, app: &mut App) {
     let whois = app.virustotal.ip_whois_items.data.attributes.whois.clone();
     let results: String = match whois {
-            Some(items) => items.to_string(),
-            None => "No Whois data found.".to_string(),
-        };
+        Some(items) => items.to_string(),
+        None => "No Whois data found.".to_string(),
+    };
 
     let results = results.split('\n').collect::<Vec<&str>>();
 

--- a/src/ui/virustotal.rs
+++ b/src/ui/virustotal.rs
@@ -214,12 +214,16 @@ where
         }],
     };
 
-    let items = app
-        .virustotal
+    let items = match &app.virustotal
         .ip_whois_items
         .data
         .attributes
-        .whois
+        .whois {
+            Some(items) => items.to_string(),
+            None => "N/A".to_string(),
+        };
+
+    let items = items
         .split('\n')
         .collect::<Vec<&str>>()
         .into_iter()

--- a/src/ui/virustotal.rs
+++ b/src/ui/virustotal.rs
@@ -214,14 +214,10 @@ where
         }],
     };
 
-    let items = match &app.virustotal
-        .ip_whois_items
-        .data
-        .attributes
-        .whois {
-            Some(items) => items.to_string(),
-            None => "N/A".to_string(),
-        };
+    let items = match &app.virustotal.ip_whois_items.data.attributes.whois {
+        Some(items) => items.to_string(),
+        None => "N/A".to_string(),
+    };
 
     let items = items
         .split('\n')


### PR DESCRIPTION
Fixes https://github.com/wssheldon/osintui/issues/8

TLDR; the `whois` field in the `Virustotal` model needs to return an `Option<String>` instead of just `String` since it seems this key can be missing from the response entirely.

<img width="973" alt="Screen Shot 2022-10-19 at 2 47 44 PM" src="https://user-images.githubusercontent.com/114631109/196811140-2b1f489d-3a30-4e52-81f5-f9a26c4ac70b.png">
